### PR TITLE
Properly create a library called Chaiscript.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,7 +248,9 @@ set(CHAISCRIPT_LIBS stdlib parser)
 
 add_executable(chai src/main.cpp ${Chai_INCLUDES})
 target_link_libraries(chai ${LIBS} ${CHAISCRIPT_LIBS})
-target_include_directories(chai PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+add_library(chaiscript INTERFACE)
+target_include_directories(chaiscript INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 if(BUILD_SAMPLES)
   add_executable(sanity_checks src/sanity_checks.cpp)


### PR DESCRIPTION
This allows to properly use Chaiscript as submodule with CMake.

With my previous PR I completly missed the CMake target `chai` was an executable and not the library.  
I discovered there was no proper library declared for CMake. Instead of using the hackish way consisting to register the Chaiscript include directory, now its just matter to link the `chaiscript` library to your project:
```cmake
add_executable(my_stuff_using_chai main.cpp)
target_link_libraries(my_stuff_using_chai chaiscript)
```